### PR TITLE
US127235 Fix WR html editor width calculation

### DIFF
--- a/quiz/d2l-quiz-question-written-response.js
+++ b/quiz/d2l-quiz-question-written-response.js
@@ -114,7 +114,7 @@ class D2LQuizQuestionWrittenResponse extends mixinBehaviors(D2L.PolymerBehaviors
 	_config() {
 		const maxWidth = parseInt(getComputedStyle(this).getPropertyValue('--d2l-quiz-question-written-response-max-width-in-px'));
 		if (this.configData.htmlEditorUrl) {
-			const editorWidth = this.__getParameterByName('width', this.configData.htmlEditorUrl);
+			const editorWidth = +this.__getParameterByName('width', this.configData.htmlEditorUrl);
 			const actualWidth = editorWidth > maxWidth ? maxWidth : editorWidth;
 			const editor = document.createElement('iframe');
 			editor.setAttribute('scrolling', 'no');


### PR DESCRIPTION
It was adding a number to string, causing the result number to be wrong.
Added a `+` to the string so it's used as a number

https://rally1.rallydev.com/#/16349626795d/detail/userstory/521918100120